### PR TITLE
Fix upward compressor calculation

### DIFF
--- a/plugins/obs-filters/expander-filter.c
+++ b/plugins/obs-filters/expander-filter.c
@@ -382,12 +382,12 @@ static inline void process_sample(size_t idx, float *samples, float *env_buf,
 		gain = diff > 0.0f ? fmaxf(slope * diff, -60.0f) : 0.0f;
 	}
 
-	float prev_gain = gain_db[idx - 1];
+	float prev_gain = idx > 0 ? gain_db[idx - 1] : channel_gain;
 
 	/* --------------------------------- */
 	/* ballistics (attack/release)       */
 
-	if (idx > 0) {
+	if (!is_upwcomp) {
 		if (gain > prev_gain)
 			gain_db[idx] = attack_gain * prev_gain +
 				       inv_attack_gain * gain;
@@ -395,11 +395,11 @@ static inline void process_sample(size_t idx, float *samples, float *env_buf,
 			gain_db[idx] = release_gain * prev_gain +
 				       inv_release_gain * gain;
 	} else {
-		if (gain > channel_gain)
-			gain_db[idx] = attack_gain * channel_gain +
+		if (gain < prev_gain)
+			gain_db[idx] = attack_gain * prev_gain +
 				       inv_attack_gain * gain;
 		else
-			gain_db[idx] = release_gain * channel_gain +
+			gain_db[idx] = release_gain * prev_gain +
 				       inv_release_gain * gain;
 	}
 

--- a/plugins/obs-filters/expander-filter.c
+++ b/plugins/obs-filters/expander-filter.c
@@ -359,7 +359,7 @@ static inline void process_sample(size_t idx, float *samples, float *env_buf,
 	float diff = threshold - env_db;
 
 	if (is_upwcomp && env_db <= -60.0f)
-		diff = 0.0f;
+		diff = threshold + 60.0f;
 
 	/* Knee with width hard-coded to 10 dB */
 	float knee = 10.0f;


### PR DESCRIPTION
This PR contains two changes.

- When the envelope crosses -60 dB, an intermediate variable `diff` was not continuous. This PR makes `diff` continuous for the whole envelope range as drawn in the figure below.
  ![upwcomp-diff-continuous](https://user-images.githubusercontent.com/780600/213915056-67ec8d0a-5cbd-4faa-9c78-eccd98481dc0.png)



- Swaps attack and release calculation for the upward compressor.
  The attack time should be effective when the input amplitude is increasing and the release time should be effective when the input amplitude is decreasing. This is opposite to the normal expander.
  I checked the behavior of `gain` in the upward compressor applying to a -6 dB 440 Hz tone on  -66 dB white noise floor. All parameters are default; the attack time is 10 ms, the release time is 50 ms. With this PR, I confirmed the gain responds faster when the tone starts at 0.5 s in the figure below and the gain responds slower when the tone stops at 1.5 s. So, I think this modification selects the right attack and release time for the upward compressor.
  ![upwcomp-comparison](https://user-images.githubusercontent.com/780600/213914511-efc1aca4-8850-479d-a20e-582f1af2d95e.png)
