### PR TITLE
WIP: [srt-track] Allow streaming with different codec than recording

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2436,73 +2436,142 @@
                             </widget>
                            </item>
                            <item row="1" column="1">
-                            <widget class="QFrame" name="widget_8">
+                            <widget class="QStackedWidget" name="advStreamTrackWidget">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                                <horstretch>0</horstretch>
                                <verstretch>0</verstretch>
-                              </sizepolicy>
-                             </property>
-                             <layout class="QHBoxLayout" name="horizontalLayout_7">
-                              <property name="leftMargin">
-                               <number>0</number>
+			      </sizepolicy>
+			     </property>
+                             <property name="currentIndex">
+                              <number>0</number>
+			     </property>
+                             <widget class="QFrame" name="rtmpTracks">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
                               </property>
-                              <property name="topMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="rightMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="bottomMargin">
-                               <number>0</number>
-                              </property>
-                              <item>
-                               <widget class="QRadioButton" name="advOutTrack1">
-                                <property name="text">
-                                 <string notr="true">1</string>
-                                </property>
-                                <property name="checked">
-                                 <bool>true</bool>
-                                </property>
-                               </widget>
+                              <layout class="QHBoxLayout" name="horizontalLayout_7">
+                               <property name="leftMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="topMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="rightMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="bottomMargin">
+                                <number>0</number>
+                               </property>
+                               <item>
+                                <widget class="QRadioButton" name="advOutTrack1">
+                                 <property name="text">
+                                  <string notr="true">1</string>
+                                 </property>
+                                 <property name="checked">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QRadioButton" name="advOutTrack2">
+                                 <property name="text">
+                                  <string notr="true">2</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QRadioButton" name="advOutTrack3">
+                                 <property name="text">
+                                  <string notr="true">3</string>
+                                 </property>
+                                </widget>
                               </item>
-                              <item>
-                               <widget class="QRadioButton" name="advOutTrack2">
-                                <property name="text">
-                                 <string notr="true">2</string>
+                               <item>
+                                <widget class="QRadioButton" name="advOutTrack4">
+                                 <property name="text">
+                                  <string notr="true">4</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QRadioButton" name="advOutTrack5">
+                                 <property name="text">
+                                  <string notr="true">5</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QRadioButton" name="advOutTrack6">
+                                 <property name="text">
+                                  <string notr="true">6</string>
+                                 </property>
+                                </widget>
+                               </item>
+                              </layout>
+                             </widget>
+                             <widget class="QWidget" name="mpegtsTracks">
+                               <layout class="QHBoxLayout" name="horizontalLayout_mpegts">
+                                <property name="leftMargin">
+                                 <number>0</number>
                                 </property>
-                               </widget>
-                              </item>
-                              <item>
-                               <widget class="QRadioButton" name="advOutTrack3">
-                                <property name="text">
-                                 <string notr="true">3</string>
+                                <property name="topMargin">
+                                 <number>0</number>
                                 </property>
-                               </widget>
-                              </item>
-                              <item>
-                               <widget class="QRadioButton" name="advOutTrack4">
-                                <property name="text">
-                                 <string notr="true">4</string>
+                                <property name="rightMargin">
+                                 <number>0</number>
                                 </property>
-                               </widget>
-                              </item>
-                              <item>
-                               <widget class="QRadioButton" name="advOutTrack5">
-                                <property name="text">
-                                 <string notr="true">5</string>
+                                <property name="bottomMargin">
+                                 <number>0</number>
                                 </property>
-                               </widget>
-                              </item>
-                              <item>
-                               <widget class="QRadioButton" name="advOutTrack6">
-                                <property name="text">
-                                 <string notr="true">6</string>
-                                </property>
-                               </widget>
-                              </item>
-                             </layout>
-                            </widget>
+                                <item>
+                                 <widget class="QCheckBox" name="advOutMpegtsTrack1">
+                                  <property name="text">
+                                   <string notr="true">1</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <widget class="QCheckBox" name="advOutMpegtsTrack2">
+                                  <property name="text">
+                                   <string notr="true">2</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <widget class="QCheckBox" name="advOutMpegtsTrack3">
+                                  <property name="text">
+                                   <string notr="true">3</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <widget class="QCheckBox" name="advOutMpegtsTrack4">
+                                  <property name="text">
+                                   <string notr="true">4</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <widget class="QCheckBox" name="advOutMpegtsTrack5">
+                                  <property name="text">
+                                   <string notr="true">5</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                                <item>
+                                 <widget class="QCheckBox" name="advOutMpegtsTrack6">
+                                  <property name="text">
+                                   <string notr="true">6</string>
+                                  </property>
+                                 </widget>
+                                </item>
+                               </layout>
+                              </widget>
+			    </widget>
                            </item>
                            <item row="2" column="0">
                             <widget class="QLabel" name="advOutAEncLabel">
@@ -7852,6 +7921,12 @@
   <tabstop>advOutTrack4</tabstop>
   <tabstop>advOutTrack5</tabstop>
   <tabstop>advOutTrack6</tabstop>
+  <tabstop>advOutMpegtsTrack1</tabstop>
+  <tabstop>advOutMpegtsTrack2</tabstop>
+  <tabstop>advOutMpegtsTrack3</tabstop>
+  <tabstop>advOutMpegtsTrack4</tabstop>
+  <tabstop>advOutMpegtsTrack5</tabstop>
+  <tabstop>advOutMpegtsTrack6</tabstop>
   <tabstop>advOutEncoder</tabstop>
   <tabstop>advOutUseRescale</tabstop>
   <tabstop>advOutRescale</tabstop>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1597,7 +1597,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint(basicConfig, "AdvOut", "RecTracks", (1 << 0));
 	config_set_default_string(basicConfig, "AdvOut", "RecEncoder", "none");
 	config_set_default_uint(basicConfig, "AdvOut", "FLVTrack", 1);
-
+	config_set_default_uint(basicConfig, "AdvOut", "MpegtsAudioMixes", 1);
 	config_set_default_bool(basicConfig, "AdvOut", "FFOutputToFile", true);
 	config_set_default_string(basicConfig, "AdvOut", "FFFilePath",
 				  GetDefaultVideoSavePath().c_str());

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -249,6 +249,7 @@ void OBSBasicSettings::SaveStream1Settings()
 
 	main->SetService(newService);
 	main->SaveService();
+	LoadOutputSettings();
 	main->auth = auth;
 	if (!!main->auth) {
 		main->auth->LoadUI();

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -377,6 +377,7 @@ private:
 	int CurrentFLVTrack();
 	int SimpleOutGetSelectedAudioTracks();
 	int AdvOutGetSelectedAudioTracks();
+	int AdvOutGetStreamingSelectedAudioTracks();
 
 	OBSService GetStream1Service();
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -868,6 +868,17 @@ static bool get_extradata(struct ffmpeg_output *stream)
 	return true;
 }
 
+static int get_audio_mix_count(int audio_mix_mask)
+{
+	int mix_count = 0;
+	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
+		if ((audio_mix_mask & (1 << i)) != 0) {
+			mix_count++;
+		}
+	}
+	return mix_count;
+}
+
 /* set ffmpeg_config & init write_thread & capture */
 static bool set_config(struct ffmpeg_output *stream)
 {
@@ -980,13 +991,12 @@ static bool set_config(struct ffmpeg_output *stream)
 	// 3.c set audio frame size
 	config.frame_size = (int)obs_encoder_get_frame_size(aencoder);
 
-	// 3.d) set the number of tracks
-	// The UI for multiple tracks is not written for streaming outputs.
-	// When it is, modify write_packet & uncomment :
-	// config.audio_tracks = (int)obs_output_get_mixers(stream->output);
-	// config.audio_mix_count = get_audio_mix_count(config.audio_tracks);
-	config.audio_tracks = 1;
-	config.audio_mix_count = 1;
+	// 3.d) set the number of tracks ; if there's no mix_mask, one is in
+	// simple output mode where there's a single track (track 1).
+	int mix_mask = (int)obs_output_get_mixers(stream->output);
+	config.audio_tracks = mix_mask ? mix_mask : 1;
+	config.audio_mix_count =
+		mix_mask ? get_audio_mix_count(config.audio_tracks) : 1;
 
 	/* 4. Muxer & protocol settings */
 	// This requires some UI to be written for the output.
@@ -1029,7 +1039,7 @@ static bool set_config(struct ffmpeg_output *stream)
 		return false;
 	if (!obs_output_initialize_encoders2(stream->output))
 		return false;
-
+	config.frame_size = (int)obs_encoder_get_frame_size(aencoder);
 	ret = pthread_create(&stream->write_thread, NULL, write_thread, stream);
 	if (ret != 0) {
 		ffmpeg_mpegts_log_error(
@@ -1137,27 +1147,45 @@ static inline int64_t rescale_ts2(AVStream *stream, AVRational codec_time_base,
 				AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX);
 }
 
+/* Given a bitmask for the selected tracks and the mix index,
+ * this returns the stream index which will be passed to the muxer. */
+static int get_track_order(int track_config, size_t mix_index)
+{
+	int position = 0;
+	for (size_t i = 0; i < mix_index; i++) {
+		if (track_config & 1 << i)
+			position++;
+	}
+	return position;
+}
+
 /* Convert obs encoder_packet to FFmpeg AVPacket and write to circular buffer
  * where it will be processed in the write_thread by process_packet.
  */
 void mpegts_write_packet(struct ffmpeg_output *stream,
 			 struct encoder_packet *encpacket)
 {
+	int track_order;
+
 	if (stopping(stream) || !stream->ff_data.video ||
 	    !stream->ff_data.video_ctx || !stream->ff_data.audio_infos)
 		return;
-	if (!stream->ff_data.audio_infos[encpacket->track_idx].stream)
-		return;
 	bool is_video = encpacket->type == OBS_ENCODER_VIDEO;
+	if (!is_video) {
+		track_order = get_track_order(stream->ff_data.audio_tracks,
+					      encpacket->track_idx);
+		if (!stream->ff_data.audio_infos[track_order].stream)
+			return;
+	}
+
 	AVStream *avstream =
 		is_video ? stream->ff_data.video
-			 : stream->ff_data.audio_infos[encpacket->track_idx]
-				   .stream;
+			 : stream->ff_data.audio_infos[track_order].stream;
 	AVPacket *packet = NULL;
 
 	const AVRational codec_time_base =
 		is_video ? stream->ff_data.video_ctx->time_base
-			 : stream->ff_data.audio_infos[encpacket->track_idx]
+			 : stream->ff_data.audio_infos[track_order]
 				   .ctx->time_base;
 
 	packet = av_packet_alloc();
@@ -1183,6 +1211,7 @@ void mpegts_write_packet(struct ffmpeg_output *stream,
 fail:
 	av_packet_free(&packet);
 }
+
 static bool write_header(struct ffmpeg_output *stream, struct ffmpeg_data *data)
 {
 	AVDictionary *dict = NULL;


### PR DESCRIPTION
I had an issue while using the old multi audio patches with the new recording codec selection where I couldn't use a different codec for streaming from the one used for recording.  I fired up Ctrl+C and Ctrl+V and got it to build but alas it crashes when I press start stream.  It gave this warning message before crashing:
```
warning: Output 'adv_stream': Tried to use obs_output_set_mixers on an encoded output
warning: Output 'adv_stream': Tried to use obs_output_set_media on an encoded output
```
I was not able to figure out what went wrong by searching for the function names, so here is my work as far as I got.